### PR TITLE
Initial commit for develop

### DIFF
--- a/foo/lib/config/__init__.py
+++ b/foo/lib/config/__init__.py
@@ -1,0 +1,3 @@
+from .configloader import ConfigLoader, ConfigLoaderException
+
+__all__ = ['ConfigLoader', 'ConfigLoaderException']

--- a/foo/lib/config/configloader.py
+++ b/foo/lib/config/configloader.py
@@ -1,0 +1,98 @@
+import os
+from typing import Optional
+
+import boto3
+import yaml
+
+
+class ConfigLoaderException(Exception):
+    pass
+
+
+class Config:
+
+    def __init__(self, config: dict, source: str):
+        self._config = config
+        self._source = source
+
+    @property
+    def source(self):
+        return self._source
+
+    def __repr__(self):
+        return (f'Config(config={self._config!r}'
+                f'       source={self.source!r})')
+
+    def __getattr__(self, name):
+        return self._config[name]
+
+    def __getitem__(self, name):
+        return self._config[name]
+
+    def get(self, name, default=None):
+        return self._config.get(name, default)
+
+
+class ConfigLoader:
+
+    """Loads configuration files.
+
+    Source of the config depends on the currently set environment (either
+    'test' or 'prod', as dictated by the *env* file.
+    """
+
+    S3_BUCKET = 'configs'
+    _instance = None
+    _instance_ready = False
+
+    # Make this class a singleton since usually config is loaded only once.
+    def __new__(cls, *args, **kwargs):
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __init__(self, defaults: dict = {}):
+        if self._instance_ready:
+            return
+        self.defaults = defaults
+        env: str = open('env').read().strip()
+        print(f'Current environment is: {env!r}')
+        if env == 'test':
+            self._handler = self._local_loader
+        elif env == 'prod':
+            self._handler = self._s3_loader
+        self._config: Optional[Config] = None
+        self._instance_ready = True
+
+    def _local_loader(self, path: str) -> dict:
+        try:
+            with open(path) as f:
+                config = yaml.load(f)
+        except Exception:
+            raise ConfigLoaderException(f'Error opening {path}')
+        return config
+
+    def _s3_loader(self, path: str) -> dict:
+        try:
+            f = boto3.client('s3').download_fileobj(self.S3_BUCKET, path)
+            config = yaml.load(f)
+        except Exception:
+            raise ConfigLoaderException(f'Error when opening {path}')
+        return config
+
+    def load(self, path: str) -> Config:
+        if self._config:
+            return self._config
+        config = self._handler(path)
+        environ = os.environ
+        for key in config:
+            if key in environ:
+                config[key] = os.environ[key]
+        for key in self.defaults:
+            if key not in config:
+                config[key] = self.defaults[key]
+        self._config = Config(config, path)
+        return self._config
+
+    def reset(self):
+        self._config = None

--- a/test/foo/lib/config/config.yaml
+++ b/test/foo/lib/config/config.yaml
@@ -1,0 +1,3 @@
+VAR0: fizz
+VAR2: foo
+VAR3: bar

--- a/test/foo/lib/config/test_configloader.py
+++ b/test/foo/lib/config/test_configloader.py
@@ -1,0 +1,55 @@
+from unittest.mock import Mock
+
+import pytest
+
+from foo.lib.config import ConfigLoader, ConfigLoaderException
+
+
+def reset_config_loader_singleton():
+    ConfigLoader._instance = None
+    ConfigLoader._instance_ready = False
+
+
+def test_load(monkeypatch):
+    reset_config_loader_singleton()
+    monkeypatch.setenv('VAR3', 'not bar')
+    cfg_loader = ConfigLoader(defaults={'VAR0': 'default value 0',
+                                        'VAR1': 'default value 1'})
+    config = cfg_loader.load('test/foo/lib/config/config.yaml')
+    assert config._config == {'VAR0': 'fizz',
+                              'VAR1': 'default value 1',
+                              'VAR2': 'foo',
+                              'VAR3': 'not bar'}
+    assert config.source == 'test/foo/lib/config/config.yaml'
+
+
+def test_load_missing():
+    reset_config_loader_singleton()
+    cfg_loader = ConfigLoader()
+    with pytest.raises(ConfigLoaderException):
+        cfg_loader.load('test/foo/lib/config/missing-config.yaml')
+
+
+def test_is_a_singleton():
+    reset_config_loader_singleton()
+    assert ConfigLoader(defaults={'VAR0': 'default value 0'}) is ConfigLoader()
+
+
+def test_load_from_s3(monkeypatch):
+    reset_config_loader_singleton()
+    monkeypatch.setenv('VAR1', 'not bar')
+
+    mock_file = Mock(autospec='read')
+    mock_file.read.return_value = 'prod'
+    mock_open = Mock()
+    mock_open.return_value = mock_file
+    monkeypatch.setattr('builtins.open', mock_open)
+    mock_s3_loader = Mock()
+    mock_s3_loader.return_value = {'VAR0': 'foo',
+                                   'VAR1': 'bar'}
+    monkeypatch.setattr(ConfigLoader, '_s3_loader', mock_s3_loader)
+    cfg_loader = ConfigLoader()
+    config = cfg_loader.load('some/s3/path.yaml')
+    assert config._config == {'VAR0': 'foo',
+                              'VAR1': 'not bar'}
+    assert config.source == 'some/s3/path.yaml'


### PR DESCRIPTION
def __repr__(self):
        return (f'Config(config={self._config!r}'
                f'       source={self.source!r})')

!r jest nie właściwie zastosowany